### PR TITLE
Provide SQLite as a opt so any implementation can be passed in

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
       },
     "keywords": [
         "GunJS", "SQLite", "React Native", "persistance", "graph"
-    ],
-    "dependencies": {
-        "react-native-sqlite-storage": "^3.3.3"
-    }
+    ]
 }

--- a/src/gun-sqlite.js
+++ b/src/gun-sqlite.js
@@ -1,5 +1,4 @@
 import KeyValAdapter from './key-val-adapter';
-import SQLite from 'react-native-sqlite-storage';
 import coerce from './coerce';
 import processRow from './process-row';
 
@@ -18,7 +17,7 @@ const adapter = new KeyValAdapter({
         // Acquire DB connection
         const sqlOpt = opt.sqlite || {};
         sqlOpt.onReady = opt.onReady || (() => {});
-        this.db = SQLite.openDatabase({
+        this.db = sqlOpt.SQLite.openDatabase({
                 name: sqlOpt.database_name || "GunDB.db",
                 location: sqlOpt.database_location || "default"
             },


### PR DESCRIPTION
Let the user import and initialize any SQLite implementation they want, and then pass it as an option, this will allow more flexibility and  makes it really easy to use with Expo too:

```
import * as SQLite from "expo-sqlite";

import Gun from 'gun';
import GunSQLite from './gun-react-native-sqlite';
const adapter = GunSQLite.bootstrap(Gun);

const gun = new Gun({
    // Defaults
    sqlite: {
      SQLite,
      database_name: "GunDB.db",
      database_location: "default", // for concerns about location on iOS, see [here](https://github.com/andpor/react-native-sqlite-storage#opening-a-database)
      onOpen: () => {},
      onError: err => {},
      onReady: err => {
        console.log('READY')
      } // don't attempt to read/write from Gun until this has been called unless you like to live dangerously
    }
});
```